### PR TITLE
team without scores has - in Rank column

### DIFF
--- a/lib/rankings.js
+++ b/lib/rankings.js
@@ -60,7 +60,11 @@ Rank.addNumbering = function (ranks) {
       rank.orderedScores.length !== 0 && lastRank.orderedScores.length !== 0) {
       currentNumber++
     }
-    rank.number = currentNumber
+    if (rank.orderedScores.length !== 0) {
+      rank.number = currentNumber
+    } else {
+      rank.number = '-'
+    }
     lastRank = rank
   })
 }


### PR DESCRIPTION
Looked for fix to rank of teams without scores to be same as rank of lowest ranked team.
Better not to give rank. Give "-" instead
This also writes the "-" to the exported csv file. 
